### PR TITLE
Formalize C locale so you can actually generate it

### DIFF
--- a/localedata/locales/C
+++ b/localedata/locales/C
@@ -1,0 +1,417 @@
+comment_char %
+escape_char /
+
+% This file is part of the GNU C Library and contains locale data.
+% The Free Software Foundation does not claim any copyright interest
+% in the locale data contained in this file.  The foregoing does not
+% affect the license of the GNU C Library as a whole.  It does not
+% exempt you from the conditions of the license if your use would
+% otherwise be governed by that license.
+
+% POSIX Standard Locale
+%
+% As per ISO/IEC 9945-2:1993 specifications
+% except for these additional identifying comments
+%
+% Source: ISO/IEC JTC1/SC22/WG15
+% Address: C/O DKUUG, Fruebjergvej 3
+%    DK-2100 Copenhagen O, Denmark
+% Contact: Keld Simonsen
+% Email: Keld.Simonsen@dkuug.dk
+% Tel: +45 - 39179944
+% Fax: +45 - 31208948
+% Language: POSIX
+% Territory:
+% Revision: 1.1
+% Date: 1997-03-15
+% Application: general
+% Users: general
+
+LC_IDENTIFICATION
+title      "Formal definition of the default C locale"
+source     "paulyc"
+address    "https://github.com/paulyc/glibc/tree/paulyc/formalize-c-locale"
+contact    ""
+email      "paulyc@quetzalcoatl.us"
+tel        "+19173380001"
+fax        ""
+language   "C"
+territory  "Worldwide"
+revision   "1.0"
+date       "2020-05-22"
+
+category "i18n:2012";LC_IDENTIFICATION
+category "i18n:2012";LC_CTYPE
+category "i18n:2012";LC_COLLATE
+category "i18n:2012";LC_TIME
+category "i18n:2012";LC_NUMERIC
+category "i18n:2012";LC_MONETARY
+category "i18n:2012";LC_MESSAGES
+category "i18n:2012";LC_PAPER
+category "i18n:2012";LC_NAME
+category "i18n:2012";LC_ADDRESS
+category "i18n:2012";LC_TELEPHONE
+category "i18n:2012";LC_MEASUREMENT
+END LC_IDENTIFICATION
+
+LC_CTYPE
+% The following is the POSIX Locale LC_CTYPE.
+% "alpha" is by default "upper" and "lower"
+% "alnum" is by definiton "alpha" and "digit"
+% "print" is by default "alnum", "punct" and the <U0020> character
+% "graph" is by default "alnum" and "punct"
+%
+upper   <U0041>;<U0042>;<U0043>;<U0044>;<U0045>;<U0046>;<U0047>;<U0048>;/
+        <U0049>;<U004A>;<U004B>;<U004C>;<U004D>;<U004E>;<U004F>;<U0050>;/
+        <U0051>;<U0052>;<U0053>;<U0054>;<U0055>;<U0056>;<U0057>;<U0058>;/
+        <U0059>;<U005A>
+%
+lower   <U0061>;<U0062>;<U0063>;<U0064>;<U0065>;<U0066>;<U0067>;<U0068>;/
+        <U0069>;<U006A>;<U006B>;<U006C>;<U006D>;<U006E>;<U006F>;<U0070>;/
+        <U0071>;<U0072>;<U0073>;<U0074>;<U0075>;<U0076>;<U0077>;<U0078>;/
+        <U0079>;<U007A>
+%
+digit   <U0030>;<U0031>;<U0032>;<U0033>;<U0034>;/
+        <U0035>;<U0036>;<U0037>;<U0038>;<U0039>
+%
+space   <U0009>;<U000A>;<U000B>;<U000C>;/
+        <U000D>;<U0020>
+%
+cntrl   <U0007>;<U0008>;<U0009>;<U000A>;<U000B>;/
+        <U000C>;<U000D>;/
+        <U0000>;<U0001>;<U0002>;<U0003>;<U0004>;<U0005>;<U0006>;<U000E>;/
+        <U000F>;<U0010>;<U0011>;<U0012>;<U0013>;<U0014>;<U0015>;<U0016>;/
+        <U0017>;<U0018>;<U0019>;<U001A>;<U001B>;<U001C>;<U001D>;<U001E>;/
+        <U001F>;<U007F>
+%
+punct   <U0021>;<U0022>;<U0023>;/
+        <U0024>;<U0025>;<U0026>;<U0027>;/
+        <U0028>;<U0029>;<U002A>;/
+        <U002B>;<U002C>;<U002D>;<U002E>;<U002F>;/
+        <U003A>;<U003B>;<U003C>;<U003D>;/
+        <U003E>;<U003F>;<U0040>;/
+        <U005B>;<U005C>;<U005D>;/
+        <U005E>;<U005F>;<U0060>;/
+        <U007B>;<U007C>;<U007D>;<U007E>
+%
+xdigit  <U0030>;<U0031>;<U0032>;<U0033>;<U0034>;<U0035>;<U0036>;<U0037>;/
+        <U0038>;<U0039>;<U0041>;<U0042>;<U0043>;<U0044>;<U0045>;<U0046>;/
+        <U0061>;<U0062>;<U0063>;<U0064>;<U0065>;<U0066>
+%
+blank   <U0020>;<U0009>
+%
+tolower (<U0041>,<U0061>);(<U0042>,<U0062>);(<U0043>,<U0063>);/
+        (<U0044>,<U0064>);(<U0045>,<U0065>);(<U0046>,<U0066>);/
+        (<U0047>,<U0067>);(<U0048>,<U0068>);(<U0049>,<U0069>);/
+        (<U004A>,<U006A>);(<U004B>,<U006B>);(<U004C>,<U006C>);/
+        (<U004D>,<U006D>);(<U004E>,<U006E>);(<U004F>,<U006F>);/
+        (<U0050>,<U0070>);(<U0051>,<U0071>);(<U0052>,<U0072>);/
+        (<U0053>,<U0073>);(<U0054>,<U0074>);(<U0055>,<U0075>);/
+        (<U0056>,<U0076>);(<U0057>,<U0077>);(<U0058>,<U0078>);/
+        (<U0059>,<U0079>);(<U005A>,<U007A>)
+%
+toupper (<U0061>,<U0041>);(<U0062>,<U0042>);(<U0063>,<U0043>);/
+        (<U0064>,<U0044>);(<U0065>,<U0045>);(<U0066>,<U0046>);/
+        (<U0067>,<U0047>);(<U0068>,<U0048>);(<U0069>,<U0049>);/
+        (<U006A>,<U004A>);(<U006B>,<U004B>);(<U006C>,<U004C>);/
+        (<U006D>,<U004D>);(<U006E>,<U004E>);(<U006F>,<U004F>);/
+        (<U0070>,<U0050>);(<U0071>,<U0051>);(<U0072>,<U0052>);/
+        (<U0073>,<U0053>);(<U0074>,<U0054>);(<U0075>,<U0055>);/
+        (<U0076>,<U0056>);(<U0077>,<U0057>);(<U0078>,<U0058>);/
+        (<U0079>,<U0059>);(<U007A>,<U005A>)
+END LC_CTYPE
+
+LC_COLLATE
+% This is the POSIX Locale definition for the LC_COLLATE category.
+% The order is the same as in the ASCII code set.
+order_start forward
+<U0000>
+<U0001>
+<U0002>
+<U0003>
+<U0004>
+<U0005>
+<U0006>
+<U0007>
+<U0008>
+<U0009>
+<U000A>
+<U000B>
+<U000C>
+<U000D>
+<U000E>
+<U000F>
+<U0010>
+<U0011>
+<U0012>
+<U0013>
+<U0014>
+<U0015>
+<U0016>
+<U0017>
+<U0018>
+<U0019>
+<U001A>
+<U001B>
+<U001C>
+<U001D>
+<U001E>
+<U001F>
+<U0020>
+<U0021>
+<U0022>
+<U0023>
+<U0024>
+<U0025>
+<U0026>
+<U0027>
+<U0028>
+<U0029>
+<U002A>
+<U002B>
+<U002C>
+<U002D>
+<U002E>
+<U002F>
+<U0030>
+<U0031>
+<U0032>
+<U0033>
+<U0034>
+<U0035>
+<U0036>
+<U0037>
+<U0038>
+<U0039>
+<U003A>
+<U003B>
+<U003C>
+<U003D>
+<U003E>
+<U003F>
+<U0040>
+<U0041>
+<U0042>
+<U0043>
+<U0044>
+<U0045>
+<U0046>
+<U0047>
+<U0048>
+<U0049>
+<U004A>
+<U004B>
+<U004C>
+<U004D>
+<U004E>
+<U004F>
+<U0050>
+<U0051>
+<U0052>
+<U0053>
+<U0054>
+<U0055>
+<U0056>
+<U0057>
+<U0058>
+<U0059>
+<U005A>
+<U005B>
+<U005C>
+<U005D>
+<U005E>
+<U005F>
+<U0060>
+<U0061>
+<U0062>
+<U0063>
+<U0064>
+<U0065>
+<U0066>
+<U0067>
+<U0068>
+<U0069>
+<U006A>
+<U006B>
+<U006C>
+<U006D>
+<U006E>
+<U006F>
+<U0070>
+<U0071>
+<U0072>
+<U0073>
+<U0074>
+<U0075>
+<U0076>
+<U0077>
+<U0078>
+<U0079>
+<U007A>
+<U007B>
+<U007C>
+<U007D>
+<U007E>
+<U007F>
+UNDEFINED
+order_end
+%
+END LC_COLLATE
+
+LC_MONETARY
+% This is the POSIX Locale definition for
+% the LC_MONETARY category.
+%
+int_curr_symbol     ""
+currency_symbol     ""
+mon_decimal_point   "<U002E>"
+mon_thousands_sep   ""
+mon_grouping        -1
+positive_sign       ""
+negative_sign       ""
+int_frac_digits     -1
+frac_digits         -1
+p_cs_precedes       -1
+p_sep_by_space      -1
+n_cs_precedes       -1
+n_sep_by_space      -1
+p_sign_posn         -1
+n_sign_posn         -1
+%
+END LC_MONETARY
+
+LC_NUMERIC
+% This is the POSIX Locale definition for
+% the LC_NUMERIC category.
+%
+decimal_point   "<U002E>"
+thousands_sep   ""
+grouping        -1
+%
+END LC_NUMERIC
+
+LC_TIME
+% This is the POSIX Locale definition for
+% the LC_TIME category.
+%
+% Abbreviated weekday names (%s)
+abday   "<U0053><U0075><U006E>";"<U004D><U006F><U006E>";/
+        "<U0054><U0075><U0065>";"<U0057><U0065><U0064>";/
+        "<U0054><U0068><U0075>";"<U0046><U0072><U0069>";/
+        "<U0053><U0061><U0074>"
+%
+% Full weekday names (%A)
+day     "<U0053><U0075><U006E><U0064><U0061><U0079>";/
+        "<U004D><U006F><U006E><U0064><U0061><U0079>";/
+        "<U0054><U0075><U0065><U0073><U0064><U0061><U0079>";/
+        "<U0057><U0065><U0064><U006E><U0065><U0073><U0064><U0061><U0079>";/
+        "<U0054><U0068><U0075><U0072><U0073><U0064><U0061><U0079>";/
+        "<U0046><U0072><U0069><U0064><U0061><U0079>";/
+        "<U0053><U0061><U0074><U0075><U0072><U0064><U0061><U0079>"
+%
+% Abbreviated month names (%b)
+abmon   "<U004A><U0061><U006E>";"<U0046><U0065><U0062>";/
+        "<U004D><U0061><U0072>";"<U0041><U0070><U0072>";/
+        "<U004D><U0061><U0079>";"<U004A><U0075><U006E>";/
+        "<U004A><U0075><U006C>";"<U0041><U0075><U0067>";/
+        "<U0053><U0065><U0070>";"<U004F><U0063><U0074>";/
+        "<U004E><U006F><U0076>";"<U0044><U0065><U0063>"
+%
+% Full month names (%B)
+mon     "<U004A><U0061><U006E><U0075><U0061><U0072><U0079>";/
+        "<U0046><U0065><U0062><U0072><U0075><U0061><U0072><U0079>";/
+        "<U004D><U0061><U0072><U0063><U0068>";/
+        "<U0041><U0070><U0072><U0069><U006C>";/
+        "<U004D><U0061><U0079>";/
+        "<U004A><U0075><U006E><U0065>";/
+        "<U004A><U0075><U006C><U0079>";/
+        "<U0041><U0075><U0067><U0075><U0073><U0074>";/
+        "<U0053><U0065><U0070><U0074><U0065><U006D><U0062><U0065><U0072>";/
+        "<U004F><U0063><U0074><U006F><U0062><U0065><U0072>";/
+        "<U004E><U006F><U0076><U0065><U006D><U0062><U0065><U0072>";/
+        "<U0044><U0065><U0063><U0065><U006D><U0062><U0065><U0072>"
+%
+% Equivalent of AM/PM (%p)      "AM"/"PM"
+am_pm   "<U0041><U004D>";"<U0050><U004D>"
+%
+% Appropriate date and time representation (%c)
+%       "%a %b %e %H:%M:%S %Y"
+d_t_fmt "<U0025><U0061><U0020><U0025><U0062><U0020><U0025><U0065>/
+<U0020><U0025><U0048><U003A><U0025><U004D>/
+<U003A><U0025><U0053><U0020><U0025><U0059>"
+%
+% Appropriate date representation (%x)   "%m/%d/%y"
+d_fmt   "<U0025><U006D><U002F><U0025><U0064><U002F><U0025><U0079>"
+%
+% Appropriate time representation (%X)   "%H:%M:%S"
+t_fmt   "<U0025><U0048><U003A><U0025><U004D><U003A><U0025><U0053>"
+%
+% Appropriate 12 h time representation (%r)   "%I:%M:%S %p"
+t_fmt_ampm "<U0025><U0049><U003A><U0025><U004D><U003A><U0025><U0053>/
+<U0020><U0025><U0070>"
+%
+% Appropriate date representation (date(1))   "%a %b %e %H:%M:%S %Z %Y"
+date_fmt	"<U0025><U0061><U0020><U0025><U0062><U0020><U0025><U0065><U0020><U0025><U0048><U003A><U0025><U004D><U003A><U0025><U0053><U0020><U0025><U005A><U0020><U0025><U0059>"
+END LC_TIME
+
+LC_MESSAGES
+% This is the POSIX Locale definition for
+% the LC_NUMERIC category.
+%
+yesexpr "<U005E><U005B><U0079><U0059><U005D>"
+%
+noexpr  "<U005E><U005B><U006E><U004E><U005D>"
+%
+yesstr  "<U0059><U0065><U0073>"
+%
+nostr   "<U004E><U006F>"
+END LC_MESSAGES
+
+LC_PAPER
+copy "i18n"
+END LC_PAPER
+
+% I hope this is a thing in i18n; if not, borrow en_US
+LC_NAME
+copy "i18n"
+END LC_NAME
+
+% name_fmt    "%d%t%g%t%m%t%f"
+% name_miss   "Miss."
+% name_mr     "Mr."
+% name_mrs    "Mrs."
+% name_ms     "Ms."
+
+% I hope this is a thing in i18n; if not, borrow en_US and make some stuff up
+LC_ADDRESS
+copy "i18n"
+END LC_ADDRESS
+
+% postal_fmt    "%a%N%f%N%d%N%b%N%h %s %e %r%N%T, %S %z%N%c%N"
+% country_name "United Federation of POSIXLAND"
+% country_post  "UFP"
+% country_ab2   "FP"
+% country_ab3   "UFP"
+% country_num   000
+% country_car   "UFP"
+% country_isbn  0
+% lang_name     "English"
+% lang_ab      "en"
+% lang_term    "eng"
+% lang_lib    "eng"
+
+% I hope this is a thing in i18n; if not, borrow ITU-T E.164
+
+LC_TELEPHONE
+copy "i18n"
+END LC_TELEPHONE
+
+% tel_int_fmt    "+%c%a%l"
+% tel_dom_fmt    "+%c%a%l"
+% Many countries use 011 or other variations.
+% Unsure which if any are formally standardized.
+% int_select     "00"
+
+LC_MEASUREMENT
+copy "i18n"
+END LC_MEASUREMENT


### PR DESCRIPTION
Formalize C locale so you can actually generate it and it doesn't upset software not aware of the fact that it is built into glibc when it can't be found. when it can't find it, even though it is built in to glibc, clearly not everyone is aware of that.